### PR TITLE
fix: use environment variables a USER and PW if specified

### DIFF
--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
-USER=root
-PASS=root
+if [ -z "$MONGO_INITDB_ROOT_USERNAME" ]; then
+    MONGO_INITDB_ROOT_USERNAME=root
+fi
+if [ -z "$MONGO_INITDB_ROOT_PASSWORD" ]; then
+    MONGO_INITDB_ROOT_PASSWORD=root
+fi
 DB=admin
-RS_OK=$(mongosh --quiet -u $USER -p $PASS $DB --eval "rs.status().ok" || echo -n 'FAIL')
+RS_OK=$(mongosh --quiet -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD $DB --eval "rs.status().ok" || echo -n 'FAIL')
 if [ "$RS_OK" = "FAIL" ]; then
     echo -n "initialising replica set..."
-    mongosh -u $USER -p $PASS $DB --eval "rs.initiate({_id: 'rs0', members: [ { _id: 0, host: 'localhost:27017'} ] });" || exit 1
+    mongosh -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD $DB --eval "rs.initiate({_id: 'rs0', members: [ { _id: 0, host: 'localhost:27017'} ] });" || exit 1
     echo -n "Replica set initialized..."
     exit 1
 fi
 
-MASTER_OK=$(mongosh --quiet -u $USER -p $PASS $DB --eval "rs.isMaster().ismaster" || echo -n 'FAIL')
+MASTER_OK=$(mongosh --quiet -u $MONGO_INITDB_ROOT_USERNAME -p $MONGO_INITDB_ROOT_PASSWORD $DB --eval "rs.isMaster().ismaster" || echo -n 'FAIL')
 if [ "$MASTER_OK" = "true" ]; then
     echo -n "Replica set is OK"
     exit 0
@@ -18,7 +22,3 @@ fi
 
 echo -n "Replica set not yet ready: $RS_OK"
 exit 1
-
-
-
-


### PR DESCRIPTION
The healthcheck script fails if you have a different username and password than root/root :)